### PR TITLE
Pass the field/key when errorMessage is a function

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -7,7 +7,8 @@ Also works with deep nested objects. `spected` is curried.
 
 #### Arguments
 
-1. `rules` *(Object)*: An object of rules, consisting of arrays containing predicate function / error message tuple, f.e. `{name: [[a => a.length > 2, 'Minimum length 3.']]}`
+1. `rules` *(Object)*: An object of rules, consisting of arrays containing predicate function / error message tuple, f.e. `{name: [[a => a.length > 2, 'Minimum length 3.']]}`.
+The error message can also be a function with this signature: `(value, key) => message`
 
 2. `input` *(Object)*: The data to be validated.
 
@@ -32,13 +33,15 @@ Depending on the status of the input either a `true` or a list of error messages
 ```js
 import spected from 'spected'
 
+const capitalLetterMsg = (value, key) => `The field ${key} should contain at least one uppercase letter. '${value}' is missing an uppercase letter.`
+
 const spec = {
   name: [
     [isNotEmpty, 'Name should not be  empty.']
   ],
   random: [
     [isLengthGreaterThan(7), 'Minimum Random length of 8 is required.'],
-    [hasCapitalLetter, 'Random should contain at least one uppercase letter.'],
+    [hasCapitalLetter, capitalLetterMsg],
   ]
 }
 
@@ -50,7 +53,7 @@ spected(spec, input)
 //      name: true, 
 //      random: [
 //          'Minimum Random length of 8 is required.', 
-//          'Random should contain at least one uppercase letter.'
+//          'The field random should contain at least one uppercase letter. 'r' is missing an uppercase letter.'
 //      ]
 //  }
    

--- a/src/index.js
+++ b/src/index.js
@@ -29,13 +29,13 @@ const transform = (successFn: Function, failFn: Function, input: Array<any>): an
  * @param {Object} inputs the input object - in case the predicate function needs access to dependent values
  * @returns {Boolean}
  */
-const runPredicate = ([predicate, errorMsg]: [Function, string],
-  value: any,
-  inputs: Object, field: string) => predicate(value, inputs) // eslint-disable-line no-nested-ternary
-    ? true
-    : typeof errorMsg === 'function'
-      ? errorMsg(value, field)
-      : errorMsg
+const runPredicate = ([predicate, errorMsg]:[Function, string],
+  value:any,
+  inputs:Object, field:string) => predicate(value, inputs) // eslint-disable-line no-nested-ternary
+  ? true
+  : typeof errorMsg === 'function'
+    ? errorMsg(value, field)
+    : errorMsg
 
 /**
  *

--- a/src/index.js
+++ b/src/index.js
@@ -29,13 +29,13 @@ const transform = (successFn: Function, failFn: Function, input: Array<any>): an
  * @param {Object} inputs the input object - in case the predicate function needs access to dependent values
  * @returns {Boolean}
  */
-const runPredicate = ([predicate, errorMsg]:[Function, string],
-  value:any,
-  inputs:Object) => predicate(value, inputs) // eslint-disable-line no-nested-ternary
-  ? true
-  : typeof errorMsg === 'function'
-    ? errorMsg(value)
-    : errorMsg
+const runPredicate = ([predicate, errorMsg]: [Function, string],
+  value: any,
+  inputs: Object, field: string) => predicate(value, inputs) // eslint-disable-line no-nested-ternary
+    ? true
+    : typeof errorMsg === 'function'
+      ? errorMsg(value, field)
+      : errorMsg
 
 /**
  *
@@ -50,7 +50,7 @@ export const validate = curry((successFn: Function, failFn: Function, spec: Obje
     const value = input[key]
     const predicates = spec[key]
     if (Array.isArray(predicates)) {
-      return { ...result, [key]: transform(() => successFn(value), failFn, map(f => runPredicate(f, value, input), predicates)) }
+      return { ...result, [key]: transform(() => successFn(value), failFn, map(f => runPredicate(f, value, input, key), predicates)) }
     } else if (typeof predicates === 'object') {
       return { ...result, [key]: validate(successFn, failFn, predicates, value) }
     } else if (typeof predicates === 'function') {

--- a/test/index.js
+++ b/test/index.js
@@ -14,6 +14,8 @@ import {
   not,
   path,
   prop,
+  flip,
+  uncurryN
 } from 'ramda'
 
 import spected, {validate} from '../src/'
@@ -483,12 +485,12 @@ describe('spected', () => {
       }, result)
     })
 
-    it('should pass the value to the error message if it is a function', () => {
+     it('should pass the key and the value to the error message if it is a function', () => {
       const validationRules = {
-        password: [[hasCapitalLetter, capitalLetterMsgWithValue('Password')]],
+        password: [[hasCapitalLetter, compose(flip, uncurryN(2))(capitalLetterMsgWithValue)]],
       }
-      const result = verify(validationRules, {password: 'foobar'})
-      deepEqual({password: 'Password should contain at least one uppercase letter. foobar is missing an uppercase letter.'}, result)
+      const result = verify(validationRules, { password: 'foobar' })
+      deepEqual({ password: 'password should contain at least one uppercase letter. foobar is missing an uppercase letter.' }, result)
     })
 
     it('should work with dynamic rules: an array of inputs', () => {


### PR DESCRIPTION
It is very common to include the name of the field in the error message.
I thought it convenient to include pass it when errorMessage is a function.

Here's how I'm using this feature (from my fork): 

```js
const isType = R.curry((type, field) => R.type(field) === type);
const typeMessage = (type, field) => `${field} has to be a ${type}`;
const typeRule = (type) => [
  isType(type),
  (val, field) => typeMessage(type, field)
];

const validationRules = {
  name: [typeRule("String")]
}
```
