### PR TITLE
Pass the top-level inputs object to the predicate functions as a third argument.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -31,7 +31,7 @@ const transform = (successFn: Function, failFn: Function, input: Array<any>): an
  */
 const runPredicate = ([predicate, errorMsg]:[Function, string],
   value:any,
-  inputs:Object, field:string) => predicate(value, inputs) // eslint-disable-line no-nested-ternary
+  inputs:Object, globalInput:Object, field:string) => predicate(value, inputs, globalInput) // eslint-disable-line no-nested-ternary
   ? true
   : typeof errorMsg === 'function'
     ? errorMsg(value, field)
@@ -45,20 +45,21 @@ const runPredicate = ([predicate, errorMsg]:[Function, string],
  * @param {Object|Function} input the validation input data
  * @returns {{}}
  */
-export const validate = curry((successFn: Function, failFn: Function, spec: Object, input: Object): Object => {
+export const validate = curry((successFn: Function, failFn: Function, spec: Object, input: Object, initialInput = null): Object => {
   const inputFn = typeof input === 'function' ? input : (key?: string) => key ? input : input
+  const globalInput = initialInput || input;
   const keys = Object.keys(inputFn())
   return reduce((result, key) => {
     const inputObj = inputFn(key)
     const value = inputObj[key]
     const predicates = spec[key]
     if (Array.isArray(predicates)) {
-      return { ...result, [key]: transform(() => successFn(value), failFn, map(f => runPredicate(f, value, inputObj, key), predicates)) }
+      return { ...result, [key]: transform(() => successFn(value), failFn, map(f => runPredicate(f, value, inputObj, globalInput, key), predicates)) }
     } else if (typeof predicates === 'object') {
-      return { ...result, [key]: validate(successFn, failFn, predicates, value) }
+      return { ...result, [key]: validate(successFn, failFn, predicates, value, globalInput) }
     } else if (typeof predicates === 'function') {
       const rules = predicates(value)
-      return { ...result, [key]: validate(successFn, failFn, rules, value) }
+      return { ...result, [key]: validate(successFn, failFn, rules, value, globalInput) }
     } else {
       return { ...result, [key]: successFn([]) }
     }

--- a/test/index.js
+++ b/test/index.js
@@ -95,6 +95,21 @@ describe('spected', () => {
     deepEqual({name: true}, result)
   })
 
+  it('should pass the initial inputs object to the predicate functions', () => {
+    const obj = {person: {id: 'personId'}, car: {owner: 'personId'}}
+
+    const validationRules = {
+      car: {
+        owner: [
+          [(value, values, inputValues) => (value === inputValues.person.id), 'Owner id not matching.']
+        ]
+      }
+    }
+
+    const result = spected(validationRules, obj)
+    deepEqual({ car: { owner: true }, person: true }, result)
+  })
+
   it('should handle multiple validations and return the correct errors', () => {
     const validationRules = {
       name: nameValidationRule,


### PR DESCRIPTION
Hello and thanks for this great library!
A while ago I needed to validate a structure like this one:

```
const obj = {
	person: { id: 'someId'},
    car: {
    	owner: 'someId'
    }
}
```

where the car.owner needs to match person.id in order to
pass validation. Maybe I got it totally wrong but my first attempt was:
```
const validationRules = {
	car: {
		id: [
			[
				(value, inputs) => {
						if (value === inputs.person.id) {
								return false;
						}
						return true;
				},
				'Car not owned by person.'
			]
		]
	}
}
```

It failed because the predicate function is only passed the ``car`` object and not the whole input.

This PR changed the validation function so that it passes the top-level input as a third argument to the predicate functions so that the above validation problem can be tackled like this:
```
const validationRules = {
	car: {
		id: [
			[
				(value, input, allInputs) => {
						if (value === allInputs.person.id) {
								return false;
						}
						return true;
				},
				'Car not owned by person.'
			]
		]
	}
}
```
