### PR TITLE
Update ramda dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,6 @@
     "rollup-plugin-uglify": "^2.0.1"
   },
   "dependencies": {
-    "ramda": "^0.24.1"
+    "ramda": "^0.28.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2623,9 +2623,10 @@ ramda@0.x:
   version "0.26.1"
   resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.26.1.tgz#8d41351eb8111c55353617fc3bbffad8e4d35d06"
 
-ramda@^0.24.1:
-  version "0.24.1"
-  resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.24.1.tgz#c3b7755197f35b8dc3502228262c4c91ddb6b857"
+ramda@^0.28.0:
+  version "0.28.0"
+  resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.28.0.tgz#acd785690100337e8b063cab3470019be427cc97"
+  integrity sha512-9QnLuG/kPVgWvMQ4aODhsBUFKOUmnbUnsSXACv+NCQZcHbeb+v8Lodp8OVxtRULN1/xOyYLLaL6npE6dMq5QTA==
 
 randomatic@^3.0.0:
   version "3.1.1"


### PR DESCRIPTION
I need to solve a couple of security issues that older ramda versions have. Check all the usage and it's safe to update to latest.

